### PR TITLE
some additional login and purchase flow tests

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,3 +1,5 @@
+import { valid_users } from '../fixtures/valid_users.json'
+
 describe('saucedemo login spec', () => {
   beforeEach(() => {
     cy.visit('/')
@@ -7,9 +9,12 @@ describe('saucedemo login spec', () => {
     cy.get('#login_button_container').should('be.visible')
   })
 
-  it('should be able to login with a standard user', () => {
-    cy.login('standard_user', 'secret_sauce')
-    cy.get('.inventory_list').should('be.visible')
+  // generate login tests for each of the valid (that is, those that are allowed to login) canned saucedemo users
+  valid_users.forEach((item) => {
+    it(`Logging in with ${item.username}`, () => {
+      cy.login(item.username, item.password)
+      cy.get('.inventory_list').should('be.visible')
+    })
   })
 
   it('should not be able to login with a locked user', () => {

--- a/cypress/e2e/purchase.cy.js
+++ b/cypress/e2e/purchase.cy.js
@@ -1,0 +1,70 @@
+describe('saucedemo purchase spec', () => {
+  beforeEach(() => {
+    cy.login('standard_user', 'secret_sauce')
+  })
+
+  // TODO: refactor to make test more concise
+  it('should be able to purchase a single item', () => {
+    // add item to cart
+    cy.getByData('add-to-cart-sauce-labs-backpack').click()
+    // cart icon shows 1 item icon
+    // click cart icon to initiate purchase flow
+    cy.get('span.shopping_cart_badge').should('have.text', '1').click()
+    // cart shows expected item; on page cart.html
+    cy.location('pathname').should('equal', '/cart.html')
+    cy.get('.cart_item')
+      .should('have.length', 1)
+      .within(() => {
+        cy.get('.cart_quantity').should('have.text', '1')
+        cy.get('.inventory_item_name').should(
+          'have.text',
+          'Sauce Labs Backpack'
+        )
+        cy.get('.inventory_item_price').should('have.text', '$29.99')
+      })
+    // click Checkout button to proceed
+    cy.get('[data-test="checkout"]').click()
+    // expect name and zip form to show; on page checkout-step-one.html
+    cy.location('pathname').should('equal', '/checkout-step-one.html')
+    // enter valid first/last and zip, then click Continue button
+    cy.getByData('firstName').type('Fred')
+    cy.getByData('lastName').type('Jones')
+    cy.getByData('postalCode').type('98109')
+    cy.getByData('continue').click()
+    // confirm checkout overview shows with item/payment info/shipping info/price total; on page checkout-step-two.html
+    cy.location('pathname').should('equal', '/checkout-step-two.html')
+    cy.get('.cart_item').should('have.length', 1)
+    cy.get('.summary_info > :nth-child(1)').should(
+      'have.text',
+      'Payment Information'
+    )
+    cy.get('.summary_info > :nth-child(2)').should(
+      'have.text',
+      'SauceCard #31337'
+    )
+    cy.get('.summary_info > :nth-child(3)').should(
+      'have.text',
+      'Shipping Information'
+    )
+    cy.get('.summary_info > :nth-child(4)').should(
+      'have.text',
+      'Free Pony Express Delivery!'
+    )
+    cy.get('.summary_info > :nth-child(5)').should('have.text', 'Price Total')
+    cy.get('.summary_subtotal_label').should('have.text', 'Item total: $29.99')
+    cy.get('.summary_tax_label').should('have.text', 'Tax: $2.40')
+    cy.get('.summary_total_label').should('have.text', 'Total: $32.39')
+
+    // click Finish button
+    cy.getByData('finish').click()
+    // complete page shows with Thank you text; on page checkout-complete.html
+    cy.location('pathname').should('equal', '/checkout-complete.html')
+    cy.get('.title').should('have.text', 'Checkout: Complete!')
+    cy.get('.complete-header').should('have.text', 'Thank you for your order!')
+    // click Back Home button
+    cy.getByData('back-to-products').click()
+    // confirm taken back to inventory page
+    cy.location('pathname').should('equal', '/inventory.html')
+    cy.get('span.shopping_cart_badge').should('not.exist')
+  })
+})

--- a/cypress/fixtures/valid_users.json
+++ b/cypress/fixtures/valid_users.json
@@ -1,0 +1,25 @@
+{
+  "valid_users" : [
+    {
+      "username": "standard_user",
+      "password": "secret_sauce"
+    },
+    {
+      "username": "problem_user",
+      "password": "secret_sauce"
+    },
+    {
+      "username": "performance_glitch_user",
+      "password": "secret_sauce"
+    },
+    {
+      "username": "error_user",
+      "password": "secret_sauce"
+    },
+    {
+      "username": "visual_user",
+      "password": "secret_sauce"
+    }
+    
+  ]
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -28,45 +28,9 @@ Cypress.Commands.add('getByData', (selector) => {
   return cy.get(`[data-test=${selector}]`)
 })
 
-let userCookie
 Cypress.Commands.add('login', (username, password) => {
   cy.visit('/')
   cy.getByData('username').type(username)
   cy.getByData('password').type(password, { log: false })
   cy.getByData('login-button').click()
-  //   cy.location('pathname').should('equal', '/inventory.html')
-
-  //   if (userCookie) {
-  //     cy.setCookie('session-username', userCookie.value, userCookie)
-  //     cy.visit('/inventory.html')
-  //     cy.location('pathname').should('equal', '/inventory.html')
-  //   } else {
-  //     cy.log('**log in**')
-  //     cy.visit('/')
-  // cy.getByData('username').type(username)
-  // cy.getByData('password').type(password)
-  // cy.getByData('login-button').click()
-  //     cy.location('pathname').should('equal', '/inventory.html')
-  //     cy.getCookie('session-username')
-  //       .should('exist')
-  //       .then((c) => {
-  //         userCookie = c
-  //       })
-  //   }
-  //   cy.session(
-  //     [username, password],
-  //     () => {
-  //       cy.visit('/')
-  //       cy.getByData('username').type(username)
-  //       cy.getByData('password').type(password)
-  //       cy.getByData('login-button').click()
-  //       cy.location('pathname').should('equal', '/inventory.html')
-  //     },
-  //     {
-  //       validate() {
-  //         cy.log('**validate login session**')
-  //         cy.getCookie('session-username').should('exist')
-  //       },
-  //     }
-  //   )
 })


### PR DESCRIPTION
Key changes:
- Made login test data driven to cover canned user logins
- Cleaned up login command to remove commented out remnants of attempts to wrap it in cy.session (which doesn't work because of saucedemo routing issue)
- Added initial purchase flow test, which is kind of a brute force implementation that should be refactored in a future PR to be more concise